### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -8,7 +8,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: returnS3Buckets.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       AutoPublishAlias: live
       Policies:
         - Version: "2012-10-17"
@@ -46,7 +46,7 @@ Resources:
             Action: 
               - "lambda:InvokeFunction"
             Resource: !Ref returnS3Buckets.Version
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
         Enabled: false


### PR DESCRIPTION
CloudFormation templates in aws-safe-lambda-deployments have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.